### PR TITLE
Added prefix to transformed lines

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
         "type": "git",
         "url": "https://github.com/helixquar/asciidecorator.git"
     },
-    "galleryBanner" : {
+    "galleryBanner": {
         "color": "#1e1e1e",
-        "theme" : "dark"
+        "theme": "dark"
     },
     "categories": [
         "Formatters",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,8 +21,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     var settings = new Settings();
 
-    if(!settings.Enabled)
-    {
+    if(!settings.Enabled) {
         console.log("The extension \"asciidecorator\" is disabled.");
         return;
     }
@@ -156,6 +155,10 @@ function processSelection(e: TextEditor, d: TextDocument, sel: Selection[], form
     e.edit(function (edit) {
         // iterate through the selections
         for (var x = 0; x < sel.length; x++) {
+            let prefixStart = new Position(sel[x].start.line, 0);
+            let prefixEnd = sel[x].start;
+            let prefix = d.getText(new Range(prefixStart, prefixEnd));
+
             let txt: string = d.getText(new Range(sel[x].start, sel[x].end));
             if (argsCB.length > 0) {
                 // in the case of figlet the params are test to change and font so this is hard coded
@@ -164,8 +167,10 @@ function processSelection(e: TextEditor, d: TextDocument, sel: Selection[], form
             } else {
                 txt = formatCB(txt);
             }
+            // add the prefix before every line of the selection
+            txt = txt.split("\n").join("\n"+prefix);
 
-            //replace the txt in the current select and work out any range adjustments
+            // replace the txt in the current select and work out any range adjustments
             edit.replace(sel[x], txt);
             let startPos: Position = new Position(sel[x].start.line, sel[x].start.character);
             let endPos: Position = new Position(sel[x].start.line + txt.split(/\r\n|\r|\n/).length - 1, sel[x].start.character + txt.length);


### PR DESCRIPTION
Hello!

In Atom, figlet extensions usually copy the start of the first line as the start of the others. So if the selection is in a comment, every other line is commented, and has the same indentation.

I found it very practical and missed it in your extension. I am not sure this is the way you'll want it to be done, but I wanted to get it to work for my use case (and contribute for the first time to a vscode extension).

So here it is, your comments are welcome!

```
let menu = {
  // File

  ...
```

```
let menu = {
  // ######## #### ##       ######## 
  // ##        ##  ##       ##       
  // ##        ##  ##       ##       
  // ######    ##  ##       ######   
  // ##        ##  ##       ##       
  // ##        ##  ##       ##       
  // ##       #### ######## ######## 

  ...
```

PS: By the way, I did not increase version number or anything.